### PR TITLE
Added relationship actions

### DIFF
--- a/app/api/ackbar.js
+++ b/app/api/ackbar.js
@@ -45,6 +45,9 @@ export const postLikeGame = (gameId, token) =>
 export const postOwnGame = (gameId, token) =>
   requestAckbar(`api/Player/OwnGame/${gameId}`, 'POST', { token });
 
+export const getPlayerInfo = token =>
+  requestAckbar(`api/Player/Info`, 'GET', { token });
+
 export const getRecommendations = token =>
   requestAckbar('api/Player/Recommendations', 'GET', { token });
 
@@ -64,6 +67,7 @@ export default {
   postViewGame,
   postLikeGame,
   postOwnGame,
+  getPlayerInfo,
   getRecommendations,
   postLogin,
   getReportUrls,

--- a/app/api/ackbar.js
+++ b/app/api/ackbar.js
@@ -54,8 +54,8 @@ export const getRecommendations = token =>
 export const postLogin = (email, password) =>
   requestAckbar('api/User/Login', 'POST', { email, password });
 
-export const getReportUrls = token =>
-  requestAckbar('api/Customer/GetReportUrl', 'GET', { token });
+export const getCustomerInfo = token =>
+  requestAckbar('api/Customer/Info', 'GET', { token });
 
 // deprecated
 export const postSignup = (email, password) =>
@@ -70,6 +70,6 @@ export default {
   getPlayerInfo,
   getRecommendations,
   postLogin,
-  getReportUrls,
+  getCustomerInfo,
   postSignup,
 };

--- a/app/containers/GameList/index.js
+++ b/app/containers/GameList/index.js
@@ -15,6 +15,7 @@ const mapStateToProps = createStructuredSelector({
 });
 
 const mapDispatchToProps = dispatch => ({
+  requestPlayerInfo: () => dispatch(domainActions.requestPlayerInfo()),
   requestGameList: () => dispatch(domainActions.requestGameList()),
   likeGame: id => dispatch(domainActions.likeGame(id)),
   goToRecommendations: () => dispatch(push('/recommendations')),

--- a/app/state/domain/actions.js
+++ b/app/state/domain/actions.js
@@ -5,19 +5,20 @@ import {
   LOAD_RECOMMENDATIONS,
   LOAD_TOKEN,
   UPDATE_RELATIONSHIP,
+  LOAD_CUSTOMER_INFO,
 } from './constants';
 import { selectPlayerToken } from './selectors';
 
 export default ({
   getGameList,
-  // postPlayerSignup,
+  postPlayerSignup,
   postViewGame,
   postLikeGame,
   postOwnGame,
   getPlayerInfo,
   getRecommendations,
   postLogin,
-  // getReportUrls,
+  getCustomerInfo,
   postSignup,
 }) => {
   const requestGameList = () => dispatch => {
@@ -108,8 +109,40 @@ export default ({
     });
   };
 
+  const tryPlayerSignup = (
+    email,
+    password,
+    avatarUrl,
+    collectionSize,
+    weeklyPlayTime,
+  ) => dispatch => {
+    postPlayerSignup(
+      email,
+      password,
+      avatarUrl,
+      collectionSize,
+      weeklyPlayTime,
+    ).then(({ token }) => {
+      dispatch(loadToken(token));
+      dispatch(push('/games'));
+    });
+  };
+
+  const requestCustomerInfo = () => (dispatch, getState) => {
+    const token = selectPlayerToken(getState());
+    getCustomerInfo(token)
+      .then(info => dispatch(loadCustomerInfo(info)))
+      .catch(() => {});
+  };
+
+  const loadCustomerInfo = info => ({
+    type: LOAD_CUSTOMER_INFO,
+    info,
+  });
+
   return {
     requestGameList,
+    requestCustomerInfo,
     viewGame,
     likeGame,
     ownGame,
@@ -117,5 +150,6 @@ export default ({
     requestRecommendations,
     tryLogin,
     trySignUp,
+    tryPlayerSignup,
   };
 };

--- a/app/state/domain/actions.js
+++ b/app/state/domain/actions.js
@@ -93,7 +93,14 @@ export default ({
   const tryLogin = (email, password) => dispatch => {
     postLogin(email, password).then(({ token }) => {
       dispatch(loadToken(token));
-      dispatch(push('/recommendations'));
+      getCustomerInfo(token)
+        .then(info => {
+          dispatch(loadCustomerInfo(info));
+          dispatch(push('/report'));
+        })
+        .catch(() => {
+          dispatch(push('/recommendations'));
+        });
     });
   };
 

--- a/app/state/domain/actions.js
+++ b/app/state/domain/actions.js
@@ -1,17 +1,23 @@
 import { push } from 'react-router-redux';
 import {
+  ADD_RELATIONSHIP,
   LOAD_GAME_LIST,
   LOAD_RECOMMENDATIONS,
   LOAD_TOKEN,
-  UPDATE_LIKED_GAMES,
+  UPDATE_RELATIONSHIP,
 } from './constants';
 import { selectPlayerToken } from './selectors';
 
 export default ({
-  postLikeGame,
   getGameList,
+  // postPlayerSignup,
+  postViewGame,
+  postLikeGame,
+  postOwnGame,
+  getPlayerInfo,
   getRecommendations,
   postLogin,
+  // getReportUrls,
   postSignup,
 }) => {
   const requestGameList = () => dispatch => {
@@ -25,16 +31,50 @@ export default ({
     gameList,
   });
 
-  const likeGame = gameId => (dispatch, getState) => {
+  const viewGame = gameId => (dispatch, getState) => {
     const token = selectPlayerToken(getState());
-    postLikeGame(gameId, token)
-      .then(() => dispatch(updateLikedGames(gameId)))
+    postViewGame(gameId, token)
+      .then(() => dispatch(addGameRelationship({ view: [gameId] })))
       .catch(() => {});
   };
 
-  const updateLikedGames = gameId => ({
-    type: UPDATE_LIKED_GAMES,
-    gameId,
+  const likeGame = gameId => (dispatch, getState) => {
+    const token = selectPlayerToken(getState());
+    postLikeGame(gameId, token)
+      .then(() => dispatch(addGameRelationship({ like: [gameId] })))
+      .catch(() => {});
+  };
+
+  const ownGame = gameId => (dispatch, getState) => {
+    const token = selectPlayerToken(getState());
+    postOwnGame(gameId, token)
+      .then(() => dispatch(addGameRelationship({ own: [gameId] })))
+      .catch(() => {});
+  };
+
+  const addGameRelationship = ({ view = [], like = [], own = [] }) => ({
+    type: ADD_RELATIONSHIP,
+    newRelationships: { view, like, own },
+  });
+
+  const requestPlayerInfo = () => (dispatch, getState) => {
+    const token = selectPlayerToken(getState());
+    getPlayerInfo(token)
+      .then(info =>
+        dispatch(
+          updateGameRelationship({
+            view: info.views,
+            like: info.likes,
+            own: info.owns,
+          }),
+        ),
+      )
+      .catch(() => {});
+  };
+
+  const updateGameRelationship = ({ view, like, own }) => ({
+    type: UPDATE_RELATIONSHIP,
+    relationships: { view, like, own },
   });
 
   const requestRecommendations = () => (dispatch, getState) => {
@@ -70,7 +110,10 @@ export default ({
 
   return {
     requestGameList,
+    viewGame,
     likeGame,
+    ownGame,
+    requestPlayerInfo,
     requestRecommendations,
     tryLogin,
     trySignUp,

--- a/app/state/domain/constants.js
+++ b/app/state/domain/constants.js
@@ -1,4 +1,5 @@
 export const LOAD_GAME_LIST = 'domain.games.load';
-export const UPDATE_LIKED_GAMES = 'domain.game.update.liked';
 export const LOAD_RECOMMENDATIONS = 'domain.recommendations.load';
+export const ADD_RELATIONSHIP = 'domain.relationship.add';
+export const UPDATE_RELATIONSHIP = 'domain.relationship.update';
 export const LOAD_TOKEN = 'domain.token.load';

--- a/app/state/domain/constants.js
+++ b/app/state/domain/constants.js
@@ -1,4 +1,5 @@
 export const LOAD_GAME_LIST = 'domain.games.load';
+export const LOAD_CUSTOMER_INFO = 'domain.customer.load';
 export const LOAD_RECOMMENDATIONS = 'domain.recommendations.load';
 export const ADD_RELATIONSHIP = 'domain.relationship.add';
 export const UPDATE_RELATIONSHIP = 'domain.relationship.update';

--- a/app/state/domain/reducer.js
+++ b/app/state/domain/reducer.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux';
 import player from './reducers/player';
 import games from './reducers/games';
+import customer from './reducers/customer';
 
 const domainReducer = combineReducers({
+  customer,
   player,
   games,
 });

--- a/app/state/domain/reducers/customer.js
+++ b/app/state/domain/reducers/customer.js
@@ -1,0 +1,28 @@
+import { LOAD_CUSTOMER_INFO } from '../constants';
+
+const initialState = {
+  name: '',
+  reports: {},
+};
+
+function customerReducer(state = initialState, action) {
+  switch (action.type) {
+    case LOAD_CUSTOMER_INFO:
+      return {
+        name: action.info.name,
+        reports: loadReportsAsMap(action.info.reports),
+      };
+    default:
+      return state;
+  }
+}
+
+const loadReportsAsMap = array => {
+  const map = {};
+  array.forEach(report => {
+    map[report.id] = report.reportUrl;
+  });
+  return map;
+};
+
+export default customerReducer;

--- a/app/state/domain/reducers/games.js
+++ b/app/state/domain/reducers/games.js
@@ -1,14 +1,22 @@
 import { LOAD_GAME_LIST } from '../constants';
 
-const initialState = [];
+const initialState = {};
 
 function gamesReducer(state = initialState, action) {
   switch (action.type) {
     case LOAD_GAME_LIST:
-      return action.gameList;
+      return loadGameAsMap(action.gameList);
     default:
       return state;
   }
 }
+
+const loadGameAsMap = array => {
+  const map = {};
+  array.forEach(game => {
+    map[game.id] = game;
+  });
+  return map;
+};
 
 export default gamesReducer;

--- a/app/state/domain/reducers/player.js
+++ b/app/state/domain/reducers/player.js
@@ -1,19 +1,43 @@
 import {
-  UPDATE_LIKED_GAMES,
   LOAD_RECOMMENDATIONS,
   LOAD_TOKEN,
+  ADD_RELATIONSHIP,
+  UPDATE_RELATIONSHIP,
 } from '../constants';
 
 const initialState = {
   token: '',
-  likedGames: [],
+  viewedGames: {},
+  likedGames: {},
+  ownedGames: {},
   recommendedGames: [],
 };
 
 function playerReducer(state = initialState, action) {
   switch (action.type) {
-    case UPDATE_LIKED_GAMES:
-      return { ...state, likedGames: [...state.likedGames, action.gameId] };
+    case ADD_RELATIONSHIP:
+      return {
+        ...state,
+        viewedGames: {
+          ...state.viewedGames,
+          ...makeTruthMap(action.newRelationships.view),
+        },
+        likedGames: {
+          ...state.likedGames,
+          ...makeTruthMap(action.newRelationships.like),
+        },
+        ownedGames: {
+          ...state.ownedGames,
+          ...makeTruthMap(action.newRelationships.own),
+        },
+      };
+    case UPDATE_RELATIONSHIP:
+      return {
+        ...state,
+        viewedGames: makeTruthMap(action.relationships.view),
+        likedGames: makeTruthMap(action.relationships.like),
+        ownedGames: makeTruthMap(action.relationships.own),
+      };
     case LOAD_RECOMMENDATIONS:
       return { ...state, recommendedGames: action.recommendations };
     case LOAD_TOKEN:
@@ -22,5 +46,13 @@ function playerReducer(state = initialState, action) {
       return state;
   }
 }
+
+const makeTruthMap = ids => {
+  const truthMap = {};
+  ids.forEach(id => {
+    truthMap[id] = true;
+  });
+  return truthMap;
+};
 
 export default playerReducer;

--- a/app/state/domain/selectors.js
+++ b/app/state/domain/selectors.js
@@ -2,7 +2,11 @@ import { createSelector } from 'reselect';
 
 const selectDomain = state => state.domain;
 
-export const selectGames = createSelector(selectDomain, domain => domain.games);
+const selectGamesMap = createSelector(selectDomain, domain => domain.games);
+
+export const selectGames = createSelector(selectGamesMap, gamesMap =>
+  Object.values(gamesMap),
+);
 
 export const selectPlayer = createSelector(
   selectDomain,
@@ -15,11 +19,7 @@ export const selectRecommendationIds = createSelector(
 );
 
 export const makeSelectGame = id =>
-  createSelector(
-    selectGames,
-    // TODO: ensure it is sorted and binary search
-    games => games.find(item => item.id === +id),
-  );
+  createSelector(selectGamesMap, games => games[id]);
 
 export const selectPlayerToken = createSelector(
   selectPlayer,
@@ -32,10 +32,8 @@ export const selectPlayerLikedGames = createSelector(
 );
 
 export const selectRecommendations = createSelector(
-  selectGames,
+  selectGamesMap,
   selectRecommendationIds,
   (games, recommendations) =>
-    games.filter(game =>
-      recommendations.find(recommendation => recommendation === game.id),
-    ),
+    recommendations.map(recommendation => games[recommendation]),
 );

--- a/app/tests/state/domain/domainActions.test.js
+++ b/app/tests/state/domain/domainActions.test.js
@@ -35,7 +35,7 @@ describe('Domain actions', () => {
 
       await store.dispatch(domainActions.likeGame(42));
 
-      expect(selectPlayerLikedGames(store.getState())).toEqual([42]);
+      expect(selectPlayerLikedGames(store.getState())).toEqual({ 42: true });
     });
 
     it('Should not add liked game to local field if update is not successful', async () => {
@@ -45,7 +45,7 @@ describe('Domain actions', () => {
 
       await store.dispatch(domainActions.likeGame(42));
 
-      expect(selectPlayerLikedGames(store.getState())).toEqual([]);
+      expect(selectPlayerLikedGames(store.getState())).toEqual({});
     });
   });
 

--- a/app/ui/pages/GameList.js
+++ b/app/ui/pages/GameList.js
@@ -52,6 +52,7 @@ const styles = {
 class GameList extends React.Component {
   componentDidMount() {
     this.props.requestGameList();
+    this.props.requestPlayerInfo();
   }
 
   render() {
@@ -108,6 +109,7 @@ GameList.propTypes = {
       coverImage: PropTypes.string,
     }),
   ),
+  requestPlayerInfo: PropTypes.func.isRequired,
   requestGameList: PropTypes.func.isRequired,
   goToRecommendations: PropTypes.func.isRequired,
   goToGameList: PropTypes.func.isRequired,


### PR DESCRIPTION
New info `view` and `own` are now available, as well as new actions to send them to ackbar.
New endpoint now exists for retrieving all relationships: `view`, `like` and `own`.
Also added player info updates and customer info logic.